### PR TITLE
Allow split config files and add options for building profiling, tests, haddock

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -35,11 +35,12 @@ To cleanup your local environment:
 [nix-shell:nixpkgs]$ runhaskell ./hackage.hs clean
 ```
 
-Inputs:
+Inputs are read from several YAML files. During import file names are sorted
+alphanumerically and value from later files take precedence
 
-* `packages.yaml` -- list of the packages controlled by the system
-* `repo.yaml` -- list of repositories that `packages.yaml` can link to.
-* `config.yaml` -- setting common for all packages.
+* `packages*.yaml` -- list of the packages controlled by the system
+* `repo*.yaml` -- list of repositories that `packages.yaml` can link to.
+* `config*.yaml` -- setting common for all packages.
   - `revision` hackage revision.
   - `ghc_version` GHC version to be used by `cabal2nix`. Generated files could
     be different for different GHC versions.

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -44,6 +44,11 @@ alphanumerically and value from later files take precedence
   - `revision` hackage revision.
   - `ghc_version` GHC version to be used by `cabal2nix`. Generated files could
     be different for different GHC versions.
+  - `profile` -- boolean flag on whether compile libraries with or without
+    profiling support. Default is false.
+  - `haddock` -- boolean flag on whether to build haddocks. Default is false.
+  - `tests` -- boolean flag on whether to run tests when building
+    package. Default is false.
 
 For example:
 

--- a/hackage.hs
+++ b/hackage.hs
@@ -219,8 +219,9 @@ main = do
       need $ (\x -> "nix" </> packageNixName x) <$> Map.keys pkgs_set
       need ["packages.yaml", "repo.yaml"]
       liftIO $ writeFile overlay $ unlines $ concat
-        [ [ "lib: prev:"
+        [ [ "pkgs: prev:"
           , "let"
+          , "  lib = pkgs.haskell.lib;"
           , "  adjust = drv: lib.doJailbreak (lib.disableLibraryProfiling (lib.dontCheck drv));"
           , "in"
           , "{"

--- a/nix-pkgs-generator.cabal
+++ b/nix-pkgs-generator.cabal
@@ -35,3 +35,4 @@ executable nix-pkgs-generator
                   , shake       >=0.19
                   , split       >=0.2
                   , yaml        >=0.11
+                  , directory   >=1.3


### PR DESCRIPTION
This PR add two features: 

1. Ability to split config files. This was used f\when I did migration to newer GHC. Overlays for each GHC got same revision using symlinks, but each has its own ghc_version.
2. Flags for controlling whether to build profiling/haddocks/tests